### PR TITLE
Github publish CI setup.

### DIFF
--- a/.github/workflows/expo-publish.yml
+++ b/.github/workflows/expo-publish.yml
@@ -1,0 +1,21 @@
+name: Expo Publish
+on:
+  push:
+    branches:
+      - main
+jobs:
+  publish:
+    name: Install and publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+      - uses: expo/expo-github-action@v5
+        with:
+          expo-version: 3.x
+          expo-username: ${{ secrets.EXPO_CLI_USERNAME }}
+          expo-password: ${{ secrets.EXPO_CLI_PASSWORD }}
+      - run: yarn install
+      - run: expo publish


### PR DESCRIPTION
Setup gituhub action in order to automatically deoploy changes when they get pushed to `main` branch.